### PR TITLE
Disambiguate what burn means

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,10 @@
 name: test
 
-on: [push, pull_request]
+on: [
+  push,
+  # pull_request,
+  workflow_dispatch
+]
 
 env:
   FOUNDRY_PROFILE: ci

--- a/src/ERC721I.sol
+++ b/src/ERC721I.sol
@@ -20,10 +20,7 @@ abstract contract ERC721I is ERC721, Initializable {
                               INITIALIZER
     //////////////////////////////////////////////////////////////*/
 
-    function __ERC721_init(string memory _name, string memory _symbol)
-        internal
-        onlyInitializing
-    {
+    function __ERC721_init(string memory _name, string memory _symbol) internal onlyInitializing {
         name = _name;
         symbol = _symbol;
     }

--- a/src/ERC721TokenReceiver.sol
+++ b/src/ERC721TokenReceiver.sol
@@ -4,12 +4,7 @@ pragma solidity >=0.8.0;
 /// @notice A generic interface for a contract which properly accepts ERC721 tokens.
 /// @author Solmate (https://github.com/transmissions11/solmate/blob/main/src/tokens/ERC721.sol)
 abstract contract ERC721TokenReceiver {
-    function onERC721Received(
-        address,
-        address,
-        uint256,
-        bytes calldata
-    ) external virtual returns (bytes4) {
+    function onERC721Received(address, address, uint256, bytes calldata) external virtual returns (bytes4) {
         return ERC721TokenReceiver.onERC721Received.selector;
     }
 }

--- a/src/SS2ERC721.sol
+++ b/src/SS2ERC721.sol
@@ -51,11 +51,7 @@ abstract contract SS2ERC721 is ERC721 {
     //////////////////////////////////////////////////////////////*/
 
     // borrowed from https://github.com/ensdomains/resolvers/blob/master/contracts/ResolverBase.sol
-    function bytesToAddress(bytes memory b)
-        internal
-        pure
-        returns (address payable a)
-    {
+    function bytesToAddress(bytes memory b) internal pure returns (address payable a) {
         require(b.length == 20);
         assembly {
             a := div(mload(add(b, 32)), exp(256, 12))
@@ -77,9 +73,7 @@ abstract contract SS2ERC721 is ERC721 {
 
         unchecked {
             uint256 start = (id - 1) * 20;
-            owner = bytesToAddress(
-                SSTORE2.read(_ownersPrimaryPointer, start, start + 20)
-            );
+            owner = bytesToAddress(SSTORE2.read(_ownersPrimaryPointer, start, start + 20));
         }
     }
 
@@ -122,8 +116,7 @@ abstract contract SS2ERC721 is ERC721 {
     function balanceOf(address owner) public view virtual override returns (uint256) {
         require(owner != address(0), "ZERO_ADDRESS");
 
-        int256 balance = int256(_balanceOfPrimary(owner)) +
-            _balanceOfAdjustment[owner];
+        int256 balance = int256(_balanceOfPrimary(owner)) + _balanceOfAdjustment[owner];
 
         require(balance >= 0, "OVERFLOW");
 
@@ -142,29 +135,21 @@ abstract contract SS2ERC721 is ERC721 {
         // need to use the ownerOf getter here instead of directly accessing the storage
         address owner = ownerOf(id);
 
-        require(
-            msg.sender == owner || isApprovedForAll[owner][msg.sender],
-            "NOT_AUTHORIZED"
-        );
+        require(msg.sender == owner || isApprovedForAll[owner][msg.sender], "NOT_AUTHORIZED");
 
         getApproved[id] = spender;
 
         emit Approval(owner, spender, id);
     }
 
-    function transferFrom(
-        address from,
-        address to,
-        uint256 id
-    ) public virtual override {
+    function transferFrom(address from, address to, uint256 id) public virtual override {
         // need to use the ownerOf getter here instead of directly accessing the storage
         require(from == ownerOf(id), "WRONG_FROM");
 
         require(to != address(0), "INVALID_RECIPIENT");
 
         require(
-            msg.sender == from || isApprovedForAll[from][msg.sender] || msg.sender == getApproved[id],
-            "NOT_AUTHORIZED"
+            msg.sender == from || isApprovedForAll[from][msg.sender] || msg.sender == getApproved[id], "NOT_AUTHORIZED"
         );
 
         if (to == BURN_ADDRESS) {
@@ -186,34 +171,25 @@ abstract contract SS2ERC721 is ERC721 {
     }
 
     /// @dev needs to be overridden here to invoke our custom version of transferFrom
-    function safeTransferFrom(
-        address from,
-        address to,
-        uint256 id
-    ) public virtual override {
+    function safeTransferFrom(address from, address to, uint256 id) public virtual override {
         transferFrom(from, to, id);
 
         require(
-            to.code.length == 0 ||
-                ERC721TokenReceiver(to).onERC721Received(msg.sender, from, id, "") ==
-                ERC721TokenReceiver.onERC721Received.selector,
+            to.code.length == 0
+                || ERC721TokenReceiver(to).onERC721Received(msg.sender, from, id, "")
+                    == ERC721TokenReceiver.onERC721Received.selector,
             "UNSAFE_RECIPIENT"
         );
     }
 
     /// @dev needs to be overridden here to invoke our custom version of transferFrom
-    function safeTransferFrom(
-        address from,
-        address to,
-        uint256 id,
-        bytes calldata data
-    ) public virtual override {
+    function safeTransferFrom(address from, address to, uint256 id, bytes calldata data) public virtual override {
         transferFrom(from, to, id);
 
         require(
-            to.code.length == 0 ||
-                ERC721TokenReceiver(to).onERC721Received(msg.sender, from, id, data) ==
-                ERC721TokenReceiver.onERC721Received.selector,
+            to.code.length == 0
+                || ERC721TokenReceiver(to).onERC721Received(msg.sender, from, id, data)
+                    == ERC721TokenReceiver.onERC721Received.selector,
             "UNSAFE_RECIPIENT"
         );
     }
@@ -223,11 +199,7 @@ abstract contract SS2ERC721 is ERC721 {
     //////////////////////////////////////////////////////////////*/
 
     /// @dev specialized version that performs a batch mint with no safeMint checks
-    function _mint(address pointer)
-        internal
-        virtual
-        returns (uint256 numMinted)
-    {
+    function _mint(address pointer) internal virtual returns (uint256 numMinted) {
         require(_ownersPrimaryPointer == address(0), "ALREADY_MINTED");
 
         bytes memory addresses = SSTORE2.read(pointer);
@@ -237,7 +209,7 @@ abstract contract SS2ERC721 is ERC721 {
         numMinted = length / 20;
         address prev = address(0);
 
-        for (uint256 i = 0; i < numMinted; ) {
+        for (uint256 i = 0; i < numMinted;) {
             address to;
 
             assembly {
@@ -267,21 +239,13 @@ abstract contract SS2ERC721 is ERC721 {
         _ownersPrimaryPointer = pointer;
     }
 
-    function _safeMint(address pointer)
-        internal
-        virtual
-        returns (uint256 numMinted)
-    {
+    function _safeMint(address pointer) internal virtual returns (uint256 numMinted) {
         numMinted = _safeMint(pointer, "");
     }
 
     /// @dev specialized version that performs a batch mint with a safeMint check at each iteration
     /// @dev needs to be kept in sync with _mint(address)
-    function _safeMint(address pointer, bytes memory data)
-        internal
-        virtual
-        returns (uint256 numMinted)
-    {
+    function _safeMint(address pointer, bytes memory data) internal virtual returns (uint256 numMinted) {
         require(_ownersPrimaryPointer == address(0), "ALREADY_MINTED");
 
         bytes memory addresses = SSTORE2.read(pointer);
@@ -291,7 +255,7 @@ abstract contract SS2ERC721 is ERC721 {
         numMinted = length / 20;
         address prev = address(0);
 
-        for (uint256 i = 0; i < numMinted; ) {
+        for (uint256 i = 0; i < numMinted;) {
             address to;
 
             assembly {
@@ -316,10 +280,7 @@ abstract contract SS2ERC721 is ERC721 {
                 )
             }
 
-            require(
-                _checkOnERC721Received(address(0), to, i, data),
-                "UNSAFE_RECIPIENT"
-            );
+            require(_checkOnERC721Received(address(0), to, i, data), "UNSAFE_RECIPIENT");
         }
 
         // we do not explicitly set balanceOf for the primary owners
@@ -357,24 +318,15 @@ abstract contract SS2ERC721 is ERC721 {
      * @param data bytes optional data to send along with the call
      * @return bool whether the call correctly returned the expected magic value
      */
-    function _checkOnERC721Received(
-        address from,
-        address to,
-        uint256 tokenId,
-        bytes memory data
-    ) private returns (bool) {
+    function _checkOnERC721Received(address from, address to, uint256 tokenId, bytes memory data)
+        private
+        returns (bool)
+    {
         if (to.code.length == 0) {
             return true;
         }
 
-        try
-            ERC721TokenReceiver(to).onERC721Received(
-                msg.sender,
-                from,
-                tokenId,
-                data
-            )
-        returns (bytes4 retval) {
+        try ERC721TokenReceiver(to).onERC721Received(msg.sender, from, tokenId, data) returns (bytes4 retval) {
             return retval == ERC721TokenReceiver.onERC721Received.selector;
         } catch (bytes memory reason) {
             if (reason.length == 0) {

--- a/src/SS2ERC721I.sol
+++ b/src/SS2ERC721I.sol
@@ -18,10 +18,7 @@ abstract contract SS2ERC721I is SS2ERC721, Initializable {
                               INITIALIZER
     //////////////////////////////////////////////////////////////*/
 
-    function __SS2ERC721_init(string memory _name, string memory _symbol)
-        internal
-        onlyInitializing
-    {
+    function __SS2ERC721_init(string memory _name, string memory _symbol) internal onlyInitializing {
         name = _name;
         symbol = _symbol;
     }

--- a/src/utils/Initializable.sol
+++ b/src/utils/Initializable.sol
@@ -31,10 +31,7 @@ abstract contract Initializable {
     modifier initializer() {
         bool isTopLevelCall = _initState == InitState.NOT_INITIALIZED;
 
-        require(
-            (isTopLevelCall) || (_initState == InitState.INITIALIZING),
-            "ALREADY_INITIALIZED"
-        );
+        require((isTopLevelCall) || (_initState == InitState.INITIALIZING), "ALREADY_INITIALIZED");
         if (isTopLevelCall) {
             _initState = InitState.INITIALIZING;
         }
@@ -52,10 +49,7 @@ abstract contract Initializable {
 
     /// locks the contract, preventing any further initialization
     function _lockInitializers() internal virtual {
-        require(
-            _initState == InitState.NOT_INITIALIZED,
-            "MUST_BE_NOT_INITIALIZED"
-        );
+        require(_initState == InitState.NOT_INITIALIZED, "MUST_BE_NOT_INITIALIZED");
         _initState = InitState.INITIALIZED;
         emit Initialized();
     }

--- a/test/SS2ERC721.t.sol
+++ b/test/SS2ERC721.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity >=0.8.0;
 
-import {Test} from "forge-std/Test.sol";
+import {Test, console2} from "forge-std/Test.sol";
 
 import {Owned} from "solmate/auth/Owned.sol";
 import {SSTORE2} from "solmate/utils/SSTORE2.sol";
@@ -15,12 +15,12 @@ contract ERC721Recipient is ERC721TokenReceiver {
     uint256 public id;
     bytes public data;
 
-    function onERC721Received(
-        address _operator,
-        address _from,
-        uint256 _id,
-        bytes calldata _data
-    ) public virtual override returns (bytes4) {
+    function onERC721Received(address _operator, address _from, uint256 _id, bytes calldata _data)
+        public
+        virtual
+        override
+        returns (bytes4)
+    {
         operator = _operator;
         from = _from;
         id = _id;
@@ -31,40 +31,21 @@ contract ERC721Recipient is ERC721TokenReceiver {
 }
 
 contract RevertingERC721Recipient is ERC721TokenReceiver {
-    function onERC721Received(
-        address,
-        address,
-        uint256,
-        bytes calldata
-    ) public virtual override returns (bytes4) {
+    function onERC721Received(address, address, uint256, bytes calldata) public virtual override returns (bytes4) {
         revert("NO_THANKS");
     }
 }
 
 contract WrongReturnDataERC721Recipient is ERC721TokenReceiver {
-    function onERC721Received(
-        address,
-        address,
-        uint256,
-        bytes calldata
-    ) public virtual override returns (bytes4) {
+    function onERC721Received(address, address, uint256, bytes calldata) public virtual override returns (bytes4) {
         return 0xCAFEBEEF;
     }
 }
 
 contract MockERC721 is SS2ERC721, Owned {
-    constructor(string memory _name, string memory _symbol)
-        SS2ERC721(_name, _symbol)
-        Owned(msg.sender)
-        {}
+    constructor(string memory _name, string memory _symbol) SS2ERC721(_name, _symbol) Owned(msg.sender) {}
 
-    function tokenURI(uint256)
-        public
-        pure
-        virtual
-        override
-        returns (string memory)
-    {}
+    function tokenURI(uint256) public pure virtual override returns (string memory) {}
 
     function safeMint(address addr) public {
         address pointer = SSTORE2.write(abi.encodePacked(addr));
@@ -76,19 +57,12 @@ contract MockERC721 is SS2ERC721, Owned {
         _safeMint(pointer);
     }
 
-    function safeMint(
-        address addr1,
-        bytes memory data
-    ) public {
+    function safeMint(address addr1, bytes memory data) public {
         address pointer = SSTORE2.write(abi.encodePacked(addr1));
         _safeMint(pointer, data);
     }
 
-    function safeMint(
-        address addr1,
-        address addr2,
-        bytes memory data
-    ) public {
+    function safeMint(address addr1, address addr2, bytes memory data) public {
         address pointer = SSTORE2.write(abi.encodePacked(addr1, addr2));
         _safeMint(pointer, data);
     }
@@ -414,75 +388,42 @@ contract ERC721Test is Test {
         token.mint(address(this));
 
         vm.expectRevert();
-        token.safeTransferFrom(
-            address(this),
-            nonRecipient,
-            1
-        );
+        token.safeTransferFrom(address(this), nonRecipient, 1);
     }
 
     function test_safeTransferFrom_toNonERC721RecipientWithData_reverts() public {
         token.mint(address(this));
 
         vm.expectRevert();
-        token.safeTransferFrom(
-            address(this),
-            nonRecipient,
-            1,
-            "testing 123"
-        );
+        token.safeTransferFrom(address(this), nonRecipient, 1, "testing 123");
     }
 
     function test_safeTransferFrom_toRevertingERC721Recipient_reverts() public {
         token.mint(address(this));
 
         vm.expectRevert("NO_THANKS");
-        token.safeTransferFrom(
-            address(this),
-            revertingRecipient,
-            1
-        );
+        token.safeTransferFrom(address(this), revertingRecipient, 1);
     }
 
-    function test_safeTransferFrom_toRevertingERC721RecipientWithData_reverts()
-        public
-    {
+    function test_safeTransferFrom_toRevertingERC721RecipientWithData_reverts() public {
         token.mint(address(this));
 
         vm.expectRevert("NO_THANKS");
-        token.safeTransferFrom(
-            address(this),
-            revertingRecipient,
-            1,
-            "testing 123"
-        );
+        token.safeTransferFrom(address(this), revertingRecipient, 1, "testing 123");
     }
 
-    function test_safeTransferFrom_toERC721RecipientWithWrongReturnData_reverts()
-        public
-    {
+    function test_safeTransferFrom_toERC721RecipientWithWrongReturnData_reverts() public {
         token.mint(address(this));
 
         vm.expectRevert("UNSAFE_RECIPIENT");
-        token.safeTransferFrom(
-            address(this),
-            wrongReturnDataRecipient,
-            1
-        );
+        token.safeTransferFrom(address(this), wrongReturnDataRecipient, 1);
     }
 
-    function test_safeTransferFrom_toERC721RecipientWithWrongReturnDataWithData_reverts()
-        public
-    {
+    function test_safeTransferFrom_toERC721RecipientWithWrongReturnDataWithData_reverts() public {
         token.mint(address(this));
 
         vm.expectRevert("UNSAFE_RECIPIENT");
-        token.safeTransferFrom(
-            address(this),
-            wrongReturnDataRecipient,
-            1,
-            "testing 123"
-        );
+        token.safeTransferFrom(address(this), wrongReturnDataRecipient, 1, "testing 123");
     }
 
     function test_safeMint_toNonERC721Recipient_reverts() public {
@@ -492,10 +433,7 @@ contract ERC721Test is Test {
 
     function test_safeMint_toNonERC721RecipientWithData_reverts() public {
         vm.expectRevert();
-        token.safeMint(
-            nonRecipient,
-            "testing 123"
-        );
+        token.safeMint(nonRecipient, "testing 123");
     }
 
     function test_safeMint_toRevertingERC721Recipient_reverts() public {
@@ -513,9 +451,7 @@ contract ERC721Test is Test {
         token.safeMint(wrongReturnDataRecipient);
     }
 
-    function test_safeMint_toERC721RecipientWithWrongReturnDataWithData_reverts()
-        public
-    {
+    function test_safeMint_toERC721RecipientWithWrongReturnDataWithData_reverts() public {
         vm.expectRevert("UNSAFE_RECIPIENT");
         token.safeMint(wrongReturnDataRecipient, "testing 123");
     }
@@ -644,13 +580,13 @@ contract ERC721Test is Test {
 
     function testSafeTransferFromToEOA(address from, address to) public {
         from = bound_min(from, 20);
-        to   = bound_min(to, 20);
-        vm.assume(to.code.length == 0);
-        vm.assume(to != address(this));
+        to = bound_min(to, 20);
         vm.assume(to != from);
         vm.assume(to != BURN_ADDRESS);
 
         token.mint(from);
+
+        vm.assume(to.code.length == 0);
 
         vm.prank(from);
         token.setApprovalForAll(address(this), true);
@@ -687,10 +623,7 @@ contract ERC721Test is Test {
         assertEq(recipient.data(), "");
     }
 
-    function testSafeTransferFromToERC721RecipientWithData(
-        address from,
-        bytes calldata data
-    ) public {
+    function testSafeTransferFromToERC721RecipientWithData(address from, bytes calldata data) public {
         from = bound_min(from, 20);
 
         ERC721Recipient recipient = ERC721Recipient(happyRecipient);
@@ -715,9 +648,11 @@ contract ERC721Test is Test {
 
     function testSafeMintToEOA(address to) public {
         to = bound_min(to, 20);
-        vm.assume(to.code.length == 0);
 
         token.safeMint(to);
+
+        // checking after the mint, because `to` may be the deployed SSTORE2 ptr
+        vm.assume(to.code.length == 0);
 
         assertEq(token.ownerOf(1), to);
         assertEq(token.balanceOf(to), 1);
@@ -773,21 +708,13 @@ contract ERC721Test is Test {
         token.approve(to, 1);
     }
 
-    function test_transferFrom_unowned_reverts(
-        address from,
-        address to,
-        uint256 id
-    ) public {
+    function test_transferFrom_unowned_reverts(address from, address to, uint256 id) public {
         vm.assume(id != 0);
         vm.expectRevert("NOT_MINTED");
         token.transferFrom(from, to, id);
     }
 
-    function test_transferFrom_wrongFrom_reverts(
-        address owner,
-        address from,
-        address to
-    ) public {
+    function test_transferFrom_wrongFrom_reverts(address owner, address from, address to) public {
         vm.assume(owner > address(0));
         vm.assume(from != owner);
 
@@ -808,65 +735,38 @@ contract ERC721Test is Test {
         token.transferFrom(from, to, 1);
     }
 
-    function test_safeTransferFrom_toNonERC721RecipientWithData_reverts(
-        bytes calldata data
-    ) public {
+    function test_safeTransferFrom_toNonERC721RecipientWithData_reverts(bytes calldata data) public {
         token.mint(address(this));
 
         vm.expectRevert();
-        token.safeTransferFrom(
-            address(this),
-            nonRecipient,
-            1,
-            data
-        );
+        token.safeTransferFrom(address(this), nonRecipient, 1, data);
     }
 
-    function test_safeTransferFrom_toRevertingERC721RecipientWithData_reverts(
-        bytes calldata data
-    ) public {
+    function test_safeTransferFrom_toRevertingERC721RecipientWithData_reverts(bytes calldata data) public {
         token.mint(address(this));
 
         vm.expectRevert("NO_THANKS");
-        token.safeTransferFrom(
-            address(this),
-            revertingRecipient,
-            1,
-            data
-        );
+        token.safeTransferFrom(address(this), revertingRecipient, 1, data);
     }
 
-    function test_safeTransferFrom_toERC721RecipientWithWrongReturnDataWithData_reverts(
-        bytes calldata data
-    ) public {
+    function test_safeTransferFrom_toERC721RecipientWithWrongReturnDataWithData_reverts(bytes calldata data) public {
         token.mint(address(this));
 
         vm.expectRevert("UNSAFE_RECIPIENT");
-        token.safeTransferFrom(
-            address(this),
-            wrongReturnDataRecipient,
-            1,
-            data
-        );
+        token.safeTransferFrom(address(this), wrongReturnDataRecipient, 1, data);
     }
 
-    function test_safeMint_toNonERC721RecipientWithData_reverts(bytes calldata data)
-        public
-    {
+    function test_safeMint_toNonERC721RecipientWithData_reverts(bytes calldata data) public {
         vm.expectRevert("UNSAFE_RECIPIENT");
         token.safeMint(nonRecipient, data);
     }
 
-    function test_safeMint_toRevertingERC721RecipientWithData(
-        bytes calldata data
-    ) public {
+    function test_safeMint_toRevertingERC721RecipientWithData(bytes calldata data) public {
         vm.expectRevert("NO_THANKS");
         token.safeMint(revertingRecipient, data);
     }
 
-    function test_safeMint_toERC721RecipientWithWrongReturnDataWithData(
-        bytes calldata data
-    ) public {
+    function test_safeMint_toERC721RecipientWithWrongReturnDataWithData(bytes calldata data) public {
         vm.expectRevert("UNSAFE_RECIPIENT");
         token.safeMint(wrongReturnDataRecipient, data);
     }

--- a/test/SS2ERC721Basics.t.sol
+++ b/test/SS2ERC721Basics.t.sol
@@ -7,9 +7,7 @@ import {SSTORE2} from "solmate/utils/SSTORE2.sol";
 import {SS2ERC721} from "src/SS2ERC721.sol";
 
 contract BasicSS2ERC721 is SS2ERC721 {
-    constructor(string memory name_, string memory symbol_)
-        SS2ERC721(name_, symbol_)
-    {}
+    constructor(string memory name_, string memory symbol_) SS2ERC721(name_, symbol_) {}
 
     function mint(address ptr) public {
         _mint(ptr);
@@ -25,6 +23,7 @@ contract BasicERC721Test is Test {
     BasicSS2ERC721 nftContract_preminted;
     BasicSS2ERC721 nftContract_pretransferred;
 
+    address ptr1000;
 
     address private alice = makeAddr("alice");
     address private bob = makeAddr("bob");
@@ -47,6 +46,9 @@ contract BasicERC721Test is Test {
 
         vm.prank(bob);
         nftContract_pretransferred.transferFrom(bob, alice, 1);
+
+        // set up the 1000 token test
+        ptr1000 = SSTORE2.write(make(1000));
     }
 
     /// @dev code from nft-editions/utils/Addresses.sol
@@ -56,13 +58,7 @@ contract BasicERC721Test is Test {
             let data := add(addresses, 32)
 
             let addr := 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE
-            for {
-                let i := n
-            } gt(i, 0) {
-                i := sub(i, 1)
-            } {
-                mstore(add(data, sub(mul(i, 20), 32)), add(addr, i))
-            }
+            for { let i := n } gt(i, 0) { i := sub(i, 1) } { mstore(add(data, sub(mul(i, 20), 32)), add(addr, i)) }
 
             let last := add(data, mul(n, 20))
 
@@ -95,6 +91,10 @@ contract BasicERC721Test is Test {
 
     function test_mint_newcomer_1000() public {
         mint(1000);
+    }
+
+    function test_mint_existingPointer_1000() public {
+        nftContract.mint(ptr1000);
     }
 
     function test_transferFrom_initial() public {

--- a/test/SS2ERC721Specifics.t.sol
+++ b/test/SS2ERC721Specifics.t.sol
@@ -7,9 +7,7 @@ import {SSTORE2} from "solmate/utils/SSTORE2.sol";
 import {SS2ERC721} from "src/SS2ERC721.sol";
 
 contract BasicSS2ERC721 is SS2ERC721 {
-    constructor(string memory name_, string memory symbol_)
-        SS2ERC721(name_, symbol_)
-    {}
+    constructor(string memory name_, string memory symbol_) SS2ERC721(name_, symbol_) {}
 
     function mint(address ptr) public returns (uint256 numMinted) {
         numMinted = _mint(ptr);

--- a/test/SS2ERC721Specifics.t.sol
+++ b/test/SS2ERC721Specifics.t.sol
@@ -121,6 +121,16 @@ contract SS2ERC721Specifics is Test {
         token.mint(ptr);
     }
 
+    function test_transferFrom_toBurnAddressDoesBurn() public {
+        address ptr = SSTORE2.write(abi.encodePacked(address(this)));
+        token.mint(ptr);
+
+        token.transferFrom(address(this), BURN_ADDRESS, 1);
+        assertEq(token.balanceOf(address(this)), 0);
+        assertEq(token.ownerOf(1), BURN_ADDRESS);
+        assertEq(token.balanceOf(BURN_ADDRESS), 0);
+    }
+
     function test_e2e() public {
         address alice = makeAddr("alice");
         address bob = address(uint160(alice) + 1);


### PR DESCRIPTION
Anybody can `transferFrom` to the burn address (0xdead), but there is also an internal _burn function that performs no auth checks and just sends a token id to the burn address.

Disambiguate the use cases by demonstrating a public-burn (with auth check) and an onlyOwner admin-burn (with no auth checks). Both go into the _burn method, which does not increment the balance of the burn address.

It is still technically possible to mint to the burn address (in which case the burn address balance _will_ be increased), I don't see a strong reason to prevent that from happening.