### PR TITLE
🧰 Rewrite _mint in Yul

### DIFF
--- a/src/SS2ERC721.sol
+++ b/src/SS2ERC721.sol
@@ -236,16 +236,9 @@ abstract contract SS2ERC721 is ERC721 {
             }
 
             let addresses_length := sub(pointer_codesize, 1)
-            if iszero(addresses_length) {
+            if gt(mod(addresses_length, ADDRESS_SIZE_BYTES), 0) {
                 revert_invalid_addresses()
             }
-
-            if gt(mod(addresses_length, 20), 0) {
-                revert_invalid_addresses()
-            }
-
-            numMinted := div(addresses_length, 20)
-            let prev := 0
 
             // perform the SSTORE2 read
             let addresses_data := mload(FREE_MEM_PTR)
@@ -256,6 +249,8 @@ abstract contract SS2ERC721 is ERC721 {
                 addresses_length        // size
             )
 
+            numMinted := div(addresses_length, ADDRESS_SIZE_BYTES)
+            let prev := 0
             for { let i := 0 } lt(i, numMinted) { i := add(i, 1) } {
                 // compute the pointer to the recipient address
                 let to_ptr := add(addresses_data, mul(i, ADDRESS_SIZE_BYTES))

--- a/src/SS2ERC721.sol
+++ b/src/SS2ERC721.sol
@@ -261,7 +261,7 @@ abstract contract SS2ERC721 is ERC721 {
 
             numMinted := div(addresses_length, ADDRESS_SIZE_BYTES)
             let prev := 0
-            for { let i := 0 } lt(i, numMinted) { i := add(i, 1) } {
+            for { let i := 0 } lt(i, numMinted) { } {
                 // compute the pointer to the recipient address
                 let to_ptr := add(addresses_data, mul(i, ADDRESS_SIZE_BYTES))
 
@@ -278,6 +278,10 @@ abstract contract SS2ERC721 is ERC721 {
                 }
 
                 prev := to
+
+                // counter increment, can not overflow
+                // increment before emitting the event, because the first valid tokenId is 1
+                i := add(i, 1)
 
                 // borrowed from ERC721A.sol
                 // Emit the `Transfer` event

--- a/src/SS2ERC721.sol
+++ b/src/SS2ERC721.sol
@@ -206,8 +206,15 @@ abstract contract SS2ERC721 is ERC721 {
             address to;
 
             assembly {
+                // compute the pointer to the recipient address
                 let to_ptr := add(addr_0_ptr, mul(i, ADDRESS_SIZE_BYTES))
+
+                // load and shift the address to the right by 96 bits:
+                //      before: ADDR_ADDR_ADDR_ADDR_ADDR_ADDR_ADDR_ADDR_XXXXXXXXXXXXXXXXXXXXXXXX
+                //      after:  000000000000000000000000_ADDR_ADDR_ADDR_ADDR_ADDR_ADDR_ADDR_ADDR
                 to := shr(ADDRESS_OFFSET_BITS, mload(to_ptr))
+
+                // increment i (no overflow check, because it's a counter increment)
                 i := add(i, 1)
             }
 

--- a/test/SS2ERC721.t.sol
+++ b/test/SS2ERC721.t.sol
@@ -85,6 +85,8 @@ contract NonERC721Recipient {}
 
 /// @notice Test suite for ERC721 based on solmate's
 contract ERC721Test is Test {
+    event Transfer(address indexed from, address indexed to, uint256 indexed id);
+
     address internal constant BURN_ADDRESS = address(0xdead);
 
     MockERC721 token;
@@ -118,6 +120,12 @@ contract ERC721Test is Test {
     }
 
     function testMint() public {
+        vm.expectEmit(true, true, true, true);
+        emit Transfer(address(0), address(0xBEEF), 1);
+
+        vm.expectEmit(true, true, true, true);
+        emit Transfer(address(0), address(0xBFFF), 2);
+
         token.mint(address(0xBEEF), address(0xBFFF));
 
         assertEq(token.balanceOf(address(0xBEEF)), 1);

--- a/test/SS2ERC721Specifics.t.sol
+++ b/test/SS2ERC721Specifics.t.sol
@@ -32,7 +32,7 @@ contract SS2ERC721Specifics is Test {
     function test_mint_badPointer_reverts(address ptr) public {
         vm.assume(ptr.code.length == 0);
 
-        vm.expectRevert(stdError.arithmeticError);
+        vm.expectRevert("INVALID_ADDRESSES");
         token.mint(address(0));
     }
 


### PR DESCRIPTION
The mint 1000 benchmark now takes -25408 gas (-0.4%)

Savings come from:
- avoiding a spurious SLOAD when we store the primary pointer
- cleaning the upper bits of the pointer address only when necessary
- computing the data offset of `addresses` outside of the loop
- performing a single extcodesize check on the pointer
- inlining the SSTORE2.read operation