### PR TITLE
Better burn handling

### DIFF
--- a/test/SS2ERC721.t.sol
+++ b/test/SS2ERC721.t.sol
@@ -86,6 +86,8 @@ contract NonERC721Recipient {}
 /// @notice Test suite for ERC721 based on solmate's
 contract ERC721Test is Test {
     event Transfer(address indexed from, address indexed to, uint256 indexed id);
+    event Approval(address indexed owner, address indexed spender, uint256 indexed id);
+    event ApprovalForAll(address indexed owner, address indexed operator, bool approved);
 
     address internal constant BURN_ADDRESS = address(0xdead);
 
@@ -139,6 +141,9 @@ contract ERC721Test is Test {
     function testBurn() public {
         token.mint(address(0xBEEF), address(0xBFFF));
 
+        vm.expectEmit(true, true, true, true);
+        emit Transfer(address(0xBEEF), address(0xdead), 1);
+
         vm.prank(address(0xBEEF));
         token.burn(1);
 
@@ -148,6 +153,9 @@ contract ERC721Test is Test {
 
     function testApprove() public {
         token.mint(address(this));
+
+        vm.expectEmit(true, true, true, true);
+        emit Approval(address(this), address(0xBEEF), 1);
 
         token.approve(address(0xBEEF), 1);
 
@@ -186,6 +194,9 @@ contract ERC721Test is Test {
     }
 
     function testApproveAll() public {
+        vm.expectEmit(true, true, true, true);
+        emit ApprovalForAll(address(this), address(0xBEEF), true);
+
         token.setApprovalForAll(address(0xBEEF), true);
 
         assertTrue(token.isApprovedForAll(address(this), address(0xBEEF)));
@@ -480,6 +491,12 @@ contract ERC721Test is Test {
         vm.assume(to1 != address(0));
         to2 = bound_min(to2, to1);
 
+        vm.expectEmit(true, true, true, true);
+        emit Transfer(address(0), to1, 1);
+
+        vm.expectEmit(true, true, true, true);
+        emit Transfer(address(0), to2, 2);
+
         token.mint(to1, to2);
         assertEq(token.ownerOf(1), to1);
         assertEq(token.ownerOf(2), to2);
@@ -489,8 +506,10 @@ contract ERC721Test is Test {
 
     function testBurn(address to) public {
         vm.assume(to != address(0));
-
         token.mint(to);
+
+        vm.expectEmit(true, true, true, true);
+        emit Transfer(to, address(0xdead), 1);
 
         vm.prank(to);
         token.burn(1);
@@ -503,6 +522,8 @@ contract ERC721Test is Test {
     function testApprove(address to) public {
         token.mint(address(this));
 
+        vm.expectEmit(true, true, true, true);
+        emit Approval(address(this), to, 1);
         token.approve(to, 1);
 
         assertEq(token.getApproved(1), to);
@@ -524,6 +545,9 @@ contract ERC721Test is Test {
     }
 
     function testApproveAll(address to, bool approved) public {
+        vm.expectEmit(true, true, true, true);
+        emit ApprovalForAll(address(this), to, approved);
+
         token.setApprovalForAll(to, approved);
 
         assertEq(token.isApprovedForAll(address(this), to), approved);

--- a/test/SS2ERC721Specifics.t.sol
+++ b/test/SS2ERC721Specifics.t.sol
@@ -10,8 +10,6 @@ import {SS2ERC721} from "src/SS2ERC721.sol";
 import {BasicSS2ERC721} from "test/helpers/BasicSS2ERC721.sol";
 
 contract SS2ERC721Specifics is Test {
-    address internal constant BURN_ADDRESS = address(0xdEaD);
-
     BasicSS2ERC721 token;
 
     function setUp() public {
@@ -93,14 +91,18 @@ contract SS2ERC721Specifics is Test {
         token.mint(ptr);
     }
 
-    function test_transferFrom_toBurnAddressDoesBurn() public {
+    function test_transferFrom_toDeadAddr() public {
         address ptr = SSTORE2.write(abi.encodePacked(address(this)));
         token.mint(ptr);
 
-        token.transferFrom(address(this), BURN_ADDRESS, 1);
+        address burn_address = address(0xdead);
+
+        token.transferFrom(address(this), burn_address, 1);
         assertEq(token.balanceOf(address(this)), 0);
-        assertEq(token.ownerOf(1), BURN_ADDRESS);
-        assertEq(token.balanceOf(BURN_ADDRESS), 0);
+        assertEq(token.ownerOf(1), burn_address);
+
+        // this is a normal transfer, so the balance is incremented
+        assertEq(token.balanceOf(burn_address), 1);
     }
 
     function test_e2e() public {
@@ -172,10 +174,9 @@ contract SS2ERC721Specifics is Test {
         assertEq(token.balanceOf(bob), 0);
         assertEq(token.balanceOf(carol), 0);
         assertEq(token.balanceOf(dennis), 0);
-        assertEq(token.balanceOf(BURN_ADDRESS), 0);
 
-        assertEq(token.ownerOf(1), BURN_ADDRESS);
-        assertEq(token.ownerOf(2), BURN_ADDRESS);
-        assertEq(token.ownerOf(3), BURN_ADDRESS);
+        assertEq(token.ownerOf(1), address(0));
+        assertEq(token.ownerOf(2), address(0));
+        assertEq(token.ownerOf(3), address(0));
     }
 }


### PR DESCRIPTION
Instead of just sending things of 0xdEaD and having a special balance handling, let's actually support the more traditional approach of setting the owner to address(0).

To do so, we replace `mapping(uint256 => address) _ownerOfSecondary` with `mapping(uint256 => uint256) _ownerIndicator`. Instead of storing only the address of the owner, we store the address + a flag indicating if it has been burned or not.

+ some additional event testing